### PR TITLE
support install gmp

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -453,7 +453,7 @@ stamps/build-binutils-newlib: $(srcdir)/riscv-binutils
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gdb-newlib: $(srcdir)/riscv-gdb
+stamps/build-gdb-newlib: $(srcdir)/riscv-gdb stamps/build-gcc-newlib-stage2
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.


### PR DESCRIPTION
Support install gmp on gcc build and create dependency on gdb-> must be compiled after gcc phase2 so gmp will be ready for it

Also gcc Makefile changed. Check: https://github.com/gcc-mirror/gcc/compare/ee5c3db...oferShinaar:install-gmp
git commit for riscv-gcc is: 9a556c2


