### PR TITLE
Updating QEMU repo url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = ../binutils-gdb.git
 [submodule "qemu"]
 	path = qemu
-	url = https://git.qemu.org/git/qemu.git
+	url = https://github.com/qemu/qemu.git
 [submodule "libexpat"]
 	path = libexpat
 	url = https://github.com/libexpat/libexpat.git


### PR DESCRIPTION
qemu url has been changed from: `https://git.qemu.org/git/qemu.git` to `https://github.com/qemu/qemu.git`